### PR TITLE
Fix bug creating public CS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gig-tech/terraform-provider-ovc
 go 1.11
 
 require (
-	github.com/gig-tech/ovc-sdk-go v1.3.0
+	github.com/gig-tech/ovc-sdk-go v1.3.1
 	github.com/hashicorp/terraform v0.11.13
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/gig-tech/ovc-sdk-go v1.2.1-0.20190702153635-81101414c764 h1:So+5+7H4y
 github.com/gig-tech/ovc-sdk-go v1.2.1-0.20190702153635-81101414c764/go.mod h1:LPuRHlsQFu6t/SK+bs15exO4tR+JxpAZoYaAdSqs2wA=
 github.com/gig-tech/ovc-sdk-go v1.3.0 h1:mC2LD1UFOK/1i1dY/y5opanRbTS+geupxMzLv/hXmiI=
 github.com/gig-tech/ovc-sdk-go v1.3.0/go.mod h1:LPuRHlsQFu6t/SK+bs15exO4tR+JxpAZoYaAdSqs2wA=
+github.com/gig-tech/ovc-sdk-go v1.3.1 h1:Pfmh1I+Sd9nOHjv4TTEBGygM/zZxnFfoQ0DjbEBr03w=
+github.com/gig-tech/ovc-sdk-go v1.3.1/go.mod h1:LPuRHlsQFu6t/SK+bs15exO4tR+JxpAZoYaAdSqs2wA=
 github.com/go-ini/ini v1.25.4 h1:Mujh4R/dH6YL8bxuISne3xX2+qcQ9p0IxKAP6ExWoUo=
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=

--- a/ovc/resource_ovc_cloudspace.go
+++ b/ovc/resource_ovc_cloudspace.go
@@ -49,7 +49,7 @@ func resourceOvcCloudSpace() *schema.Resource {
 				Default:  "vgw",
 			},
 			"external_network_id": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
@@ -169,7 +169,7 @@ func resourceOvcCloudSpaceCreate(d *schema.ResourceData, m interface{}) error {
 		PrivateNetwork:         d.Get("private_network").(string),
 		Mode:                   d.Get("mode").(string),
 		Type:                   d.Get("type").(string),
-		ExternalnetworkID:      d.Get("external_network_id").(int),
+		ExternalnetworkID:      d.Get("external_network_id").(string),
 	}
 	if v, ok := d.GetOk("resource_limits"); ok {
 		rL := v.(map[string]interface{})

--- a/vendor/github.com/gig-tech/ovc-sdk-go/ovc/cloudspaces.go
+++ b/vendor/github.com/gig-tech/ovc-sdk-go/ovc/cloudspaces.go
@@ -24,7 +24,7 @@ type CloudSpaceConfig struct {
 	PrivateNetwork         string  `json:"privatenetwork"`
 	Mode                   string  `json:"mode"`
 	Type                   string  `json:"type"`
-	ExternalnetworkID      int     `json:"externalnetworkId"`
+	ExternalnetworkID      string  `json:"externalnetworkId"`
 }
 
 // ResourceLimits contains all information related to resource limits

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -48,7 +48,7 @@ github.com/blang/semver
 github.com/davecgh/go-spew/spew
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible
 github.com/dgrijalva/jwt-go
-# github.com/gig-tech/ovc-sdk-go v1.3.0
+# github.com/gig-tech/ovc-sdk-go v1.3.1
 github.com/gig-tech/ovc-sdk-go/ovc
 # github.com/go-ini/ini v1.25.4
 github.com/go-ini/ini


### PR DESCRIPTION
In the latest release was introduces a bug: creation of  public CS was producing error : `Not enough IP addresses` if network ID was not set. 
Reason: external ID was int, and when passed default 0, OVC is looking for the network with ID 0.

Fix: change external ID to type to string and send empty string instead of 0 as default `externalnetworkId`.

Related SDK PR:
https://github.com/gig-tech/ovc-sdk-go/pull/22